### PR TITLE
52 arreglar que las vidas funcionan mal

### DIFF
--- a/src/game/play_scene.py
+++ b/src/game/play_scene.py
@@ -108,9 +108,11 @@ class PlayScene(Scene):
             self.ecs_world.add_component(self.spawner_entity, CCooldown(2))
         ServiceLocator.sounds_service.play(self.config_texts["READY"]["sound"])
         self.attack_cooldown = self.ecs_world.create_entity()
+        self.life3_cooldown_entity = self.ecs_world.create_entity()
         self.bullet_enemy_cooldown = self.ecs_world.create_entity()
-        self.ecs_world.add_component(self.attack_cooldown, CCooldown(10))
         self.ecs_world.add_component(self.bullet_enemy_cooldown, CCooldown(3))
+        self.ecs_world.add_component(self.attack_cooldown, CCooldown(10))
+        self.ecs_world.add_component(self.life3_cooldown_entity, CCooldown(2.5))
         create_lives_display(self.ecs_world)
         create_level_flags(self.ecs_world)
             
@@ -158,7 +160,12 @@ class PlayScene(Scene):
                 self.switch_game_over = True
                 self.time_init = pygame.time.get_ticks()
                 system_clear_player_and_bullets(self.ecs_world)
-            
+            _life3_cooldown = self.ecs_world.component_for_entity(self.life3_cooldown_entity, CCooldown)
+            if _life3_cooldown.current_time > 0.1:
+                return
+            else:
+                if self._game_engine.lives == 3:
+                    self._game_engine.lives = 2
             if not self.switch_game_over and self.ecs_world.entity_exists(self._player_entity):
                
                 if not self.ecs_world.component_for_entity(self._player_entity, CCooldown).current_time > 0.1:


### PR DESCRIPTION
Se creó un componente de cooldown para manejar el tiempo en el que el jugador perdía una vida. Se verifica si tiene 3 vidas y ha pasado ese tiempo. Si es verdadero, el número de vidas pasa a 2.